### PR TITLE
Add profile view with dark mode toggle

### DIFF
--- a/AgendaPsicologica/main.py
+++ b/AgendaPsicologica/main.py
@@ -1,0 +1,38 @@
+import flet as ft
+from views.agenda import AgendaView
+from views.detalle import DetalleView
+from views.perfil import PerfilView
+
+
+def main(page: ft.Page):
+    page.title = "Agenda Psicológica Supérate"
+
+    def cambiar_vista(e):
+        """Cambia la vista según el destino seleccionado en NavigationRail."""
+        seleccion = e.control.selected_index
+        page.controls.clear()
+
+        if seleccion == 0:
+            page.add(ft.Row([nav, AgendaView()]))
+        elif seleccion == 1:
+            page.add(ft.Row([nav, DetalleView()]))
+        elif seleccion == 2:
+            page.add(ft.Row([nav, PerfilView(page)]))
+
+        page.update()
+
+    nav = ft.NavigationRail(
+        selected_index=0,
+        destinations=[
+            ft.NavigationRailDestination(icon=ft.icons.CALENDAR_MONTH, label="Agenda"),
+            ft.NavigationRailDestination(icon=ft.icons.DESCRIPTION, label="Detalle Citas"),
+            ft.NavigationRailDestination(icon=ft.icons.SETTINGS, label="Perfil"),
+        ],
+        on_change=cambiar_vista,
+    )
+
+    # Vista por defecto al abrir la app
+    page.add(ft.Row([nav, AgendaView()]))
+
+
+ft.app(target=main)

--- a/AgendaPsicologica/views/agenda.py
+++ b/AgendaPsicologica/views/agenda.py
@@ -1,0 +1,33 @@
+import flet as ft
+
+
+def AgendaView():
+    """Devuelve una vista con un DataTable de citas futuras."""
+    citas = [
+        {"fecha": "2025-06-15", "hora": "09:00 AM", "estudiante": "Juan Pérez", "estado": "Pendiente"},
+        {"fecha": "2025-06-15", "hora": "10:00 AM", "estudiante": "María López", "estado": "Confirmada"},
+        {"fecha": "2025-06-16", "hora": "11:00 AM", "estudiante": "Luis Gómez", "estado": "Pendiente"},
+        {"fecha": "2025-06-16", "hora": "12:00 PM", "estudiante": "Ana Torres", "estado": "Cancelada"},
+        {"fecha": "2025-06-17", "hora": "01:00 PM", "estudiante": "Pedro Sánchez", "estado": "Confirmada"},
+    ]
+
+    rows = [
+        ft.DataRow(cells=[
+            ft.DataCell(ft.Text(cita["fecha"])),
+            ft.DataCell(ft.Text(cita["hora"])),
+            ft.DataCell(ft.Text(cita["estudiante"])),
+            ft.DataCell(ft.Text(cita["estado"])),
+        ]) for cita in citas
+    ]
+
+    tabla = ft.DataTable(
+        columns=[
+            ft.DataColumn(label=ft.Text("Fecha")),
+            ft.DataColumn(label=ft.Text("Hora")),
+            ft.DataColumn(label=ft.Text("Estudiante")),
+            ft.DataColumn(label=ft.Text("Estado")),
+        ],
+        rows=rows,
+    )
+
+    return ft.Container(content=tabla, padding=20, expand=True)

--- a/AgendaPsicologica/views/detalle.py
+++ b/AgendaPsicologica/views/detalle.py
@@ -1,0 +1,42 @@
+import flet as ft
+
+
+def DetalleView():
+    """Devuelve una vista con tarjetas de detalle de citas."""
+    detalles_citas = [
+        {
+            "estudiante": "Juan Pérez",
+            "fecha_hora": "2025-06-15, 09:00 AM",
+            "notas": "Hablar sobre manejo del estrés académico."
+        },
+        {
+            "estudiante": "María López",
+            "fecha_hora": "2025-06-15, 10:00 AM",
+            "notas": "Revisión de seguimiento emocional."
+        },
+        {
+            "estudiante": "Luis Gómez",
+            "fecha_hora": "2025-06-16, 11:00 AM",
+            "notas": "Evaluación inicial de ansiedad."
+        }
+    ]
+
+    cards = []
+    for cita in detalles_citas:
+        card = ft.Card(
+            content=ft.Container(
+                content=ft.Column([
+                    ft.Text(cita["estudiante"], size=20, weight="bold"),
+                    ft.Text(f"Fecha y hora: {cita['fecha_hora']}"),
+                    ft.Text(f"Notas: {cita['notas']}")
+                ]),
+                padding=15
+            )
+        )
+        cards.append(card)
+
+    return ft.Container(
+        content=ft.Column(cards, scroll=ft.ScrollMode.ALWAYS),
+        padding=20,
+        expand=True
+    )

--- a/AgendaPsicologica/views/perfil.py
+++ b/AgendaPsicologica/views/perfil.py
@@ -1,0 +1,34 @@
+import flet as ft
+
+
+def PerfilView(page: ft.Page):
+    """Devuelve una vista de perfil con campos editables y modo oscuro."""
+    # estado local para modo oscuro
+    is_dark = ft.Ref[bool](False)
+
+    # controles de texto para editar perfil
+    nombre = ft.TextField(label="Nombre", width=300)
+    apellido = ft.TextField(label="Apellido", width=300)
+    edad = ft.TextField(label="Edad", width=150)
+    grado = ft.TextField(label="Grado", width=150)
+
+    def toggle_tema(e):
+        """Cambia el modo claro/oscuro."""
+        is_dark.current = e.control.value
+        page.theme_mode = ft.ThemeMode.DARK if is_dark.current else ft.ThemeMode.LIGHT
+        page.update()
+
+    switch = ft.Switch(label="🌙 Modo oscuro", on_change=toggle_tema)
+
+    perfil_icono = ft.Text("👤", size=80)
+
+    contenido = ft.Column([
+        perfil_icono,
+        nombre,
+        apellido,
+        edad,
+        grado,
+        ft.Row([switch]),
+    ], horizontal_alignment=ft.CrossAxisAlignment.CENTER)
+
+    return ft.Container(content=contenido, padding=20, expand=True)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# AgendaPsicologica
+
+Este repositorio contiene un ejemplo de proyecto en **Flet** dividido en tres partes para ser trabajado por grupos de estudiantes. La aplicación permite gestionar citas de una agenda psicológica sencilla.
+
+## Estructura
+
+```
+AgendaPsicologica/
+├── main.py          # menú principal con NavigationRail
+├── views/
+│   ├── agenda.py    # tabla de citas futuras
+│   ├── detalle.py   # tarjetas con detalles de citas
+│   └── perfil.py    # edición de perfil y cambio de tema
+```
+
+Cada archivo está comentado en español y utiliza componentes básicos de Flet como `ft.DataTable`, `ft.Card` y `ft.Container`.
+La vista de perfil permite editar datos simples y alternar entre modo claro y oscuro.
+
+Para ejecutar el proyecto instale Flet y ejecute:
+
+```bash
+pip install flet
+python AgendaPsicologica/main.py
+```


### PR DESCRIPTION
## Summary
- add a profile view showing editable fields and a dark mode switch
- update navigation to load the new view
- document profile view in README

## Testing
- `python -m py_compile AgendaPsicologica/main.py AgendaPsicologica/views/agenda.py AgendaPsicologica/views/detalle.py AgendaPsicologica/views/perfil.py`


------
https://chatgpt.com/codex/tasks/task_e_6846e708ae98832fb6db602b594cbf4d